### PR TITLE
Fix errors around reading the log files

### DIFF
--- a/lib/db/log.js
+++ b/lib/db/log.js
@@ -132,7 +132,7 @@ class Log {
             .fromCallback((cb) => {
               fs.readFile(`${Log.pathname(key)}/chunk.txt`, 'utf-8', cb)
             })
-            .then((text) => text.split('\n'))
+            .then((text) => _.compact(text.split('\n')))
             .map((pathname) => {
               return { path : pathname };
             })
@@ -172,10 +172,7 @@ class Log {
                       cb(new Error(`error reading file ${fullname}`));
                     })
                     .on('end', cb)
-                    .pipe(decoder, { end : false })
-                    .on('error', (err) => {
-                      cb(new Error(`error decoding file ${fullname}`));
-                    });
+                    .pipe(decoder, { end : false });
                 }, (err) => {
                   if(err) {
                     logger.error(err);


### PR DESCRIPTION
There are 2 errors I'm fixing here.

The most severe one is we fail to read the chunks correctly. We end up adding an empty filename '' into our list of filenames, and that causes the reading of all chunks to fail with this error:

2020-03-28T03:29:52.150Z error: error reading file  Error: error reading file
    at ReadStream.<anonymous> (/home/autoqa/tailf/lib/db/log.js:172:26)
    at ReadStream.emit (events.js:315:20)
    at internal/fs/streams.js:163:14
    at FSReqCallback.oncomplete (fs.js:159:23)



The other and least severe error is when we get an error, we have a double callback and it causes this error:

 (node:5057) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 error listeners added to [Pumpify]. Use emitter.setMaxListeners() to increase limit
 Error: Callback was already called.
     at /home/autoqa/tailf/node_modules/async/dist/async.js:966:32
     at Pumpify.<anonymous> (/home/autoqa/tailf/lib/db/log.js:177:23)
     at Pumpify.emit (events.js:327:22)
     at Pumpify.Duplexify._destroy (/home/autoqa/tailf/node_modules/duplexify/index.js:191:15)
     at /home/autoqa/tailf/node_modules/duplexify/index.js:182:10
     at processTicksAndRejections (internal/process/task_queues.js:79:11)


