### PR TITLE
Fix nonexistent file case for text/stdout/stderr

### DIFF
--- a/lib/db/log.js
+++ b/lib/db/log.js
@@ -142,7 +142,11 @@ class Log {
             })
             .catch((err) => {
               // if error reading chunk.tex
-              return Log.klaw_filenames(key);
+              return Log
+                      .klaw_filenames(key)
+                      .catch(() => {
+                        return [];
+                      })
             })
   }
 

--- a/lib/db/log.js
+++ b/lib/db/log.js
@@ -146,7 +146,7 @@ class Log {
                       .klaw_filenames(key)
                       .catch(() => {
                         return [];
-                      })
+                      });
             })
   }
 


### PR DESCRIPTION
This allows consumers of the function (reader, stdout, stderr, text).

